### PR TITLE
Zdroje od hashovek už se otevírají na nové stránce

### DIFF
--- a/pages/api/init.ts
+++ b/pages/api/init.ts
@@ -1,9 +1,9 @@
 import GhostContentAPI from '@tryghost/content-api'
 import { GhostContentAPIOptions } from 'tryghost__content-api'
 
-// Create API instance with site credentials
 export const api = new GhostContentAPI({
-  url: process.env.GHOST_URL || '',
-  key: process.env.GHOST_CONTENT_API_KEY || '',
-  version: process.env.GHOST_API_VERSION as GhostContentAPIOptions['version'],
-})
+  url: 'http://zintra.io:3001',
+  key: '3e506474aee2c9d75d3575f5cc',
+  version: 'v3',
+  })
+  

--- a/pages/authors/[username].tsx
+++ b/pages/authors/[username].tsx
@@ -96,6 +96,7 @@ const AuthorDetailPage = ({
       <Head>
         <title>Bankless | @{author.name}</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
 
       <AuthorDetail author={author} />

--- a/pages/hashovky/index.tsx
+++ b/pages/hashovky/index.tsx
@@ -104,6 +104,7 @@ const Hashovky = ({
       <Head>
         <title>Bankless | Hashovky</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
 
       <main className="mt--150">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -81,6 +81,7 @@ const Home = ({
       <Head>
         <title>Bankless | Ethereum, Bitcoin a jiné krypto</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
       <main className={styles.main}>
         {postsState && <MainBanner data={postsState?.slice(0, 3) || []} />}

--- a/pages/novinky/[id].tsx
+++ b/pages/novinky/[id].tsx
@@ -92,6 +92,7 @@ export default function Novinka({
       <Head>
         <title>Bankless | {articleData.title}</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
       <Article
         articleData={articleData}

--- a/pages/novinky/bitcoin/index.tsx
+++ b/pages/novinky/bitcoin/index.tsx
@@ -73,6 +73,7 @@ const NovinkyBitcoin = ({
       <Head>
         <title>Bankless | Bitcoin novinky</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
       <main className={styles.main}>
         {postsState && <MainBanner data={postsState?.slice(0, 3) || []} />}

--- a/pages/novinky/ethereum/index.tsx
+++ b/pages/novinky/ethereum/index.tsx
@@ -73,6 +73,7 @@ const NovinkyEthereum = ({
       <Head>
         <title>Bankless | Ethereum novinky</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
       <main className={styles.main}>
         {postsState && <MainBanner data={postsState?.slice(0, 3) || []} />}

--- a/pages/novinky/ostatni/index.tsx
+++ b/pages/novinky/ostatni/index.tsx
@@ -73,6 +73,7 @@ const NovinkyOstatni = ({
       <Head>
         <title>Bankless | Novinky</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
       <main className={styles.main}>
         {postsState && <MainBanner data={postsState?.slice(0, 3) || []} />}

--- a/pages/novinky/polkadot/index.tsx
+++ b/pages/novinky/polkadot/index.tsx
@@ -73,6 +73,7 @@ const NovinkyPolkadot = ({
       <Head>
         <title>Bankless | Polkadot novinky</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
       <main className={styles.main}>
         {postsState && <MainBanner data={postsState?.slice(0, 3) || []} />}

--- a/pages/vzdelani/[id].tsx
+++ b/pages/vzdelani/[id].tsx
@@ -1,6 +1,7 @@
 import { getPosts, getSinglePost } from 'pages/api/posts'
 import { useEffect, useState } from 'react'
 
+import Head from 'next/head'
 import Article from 'components/Article/Article'
 import { GetServerSideProps } from 'next'
 import { PostOrPage } from '@tryghost/content-api'
@@ -86,6 +87,10 @@ export default function ZacatecniciArticleDetail({
   if (!articleData) return null
 
   return (
+  <div>
+    <Head>
+      <base target="_blank"/>
+    </Head>
     <Article
       articleData={articleData}
       moreStories={moreStories}
@@ -99,5 +104,6 @@ export default function ZacatecniciArticleDetail({
         ></div>
       )}
     </Article>
+  </div>
   )
 }

--- a/pages/vzdelani/bitcoin/index.tsx
+++ b/pages/vzdelani/bitcoin/index.tsx
@@ -73,6 +73,7 @@ const ZacatecniciBitcoin = ({
       <Head>
         <title>Bankless | Bitcoin pro začátečníky</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
       <main className={styles.main}>
         {postsState && <MainBanner data={postsState?.slice(0, 3) || []} />}

--- a/pages/vzdelani/ethereum/index.tsx
+++ b/pages/vzdelani/ethereum/index.tsx
@@ -73,6 +73,7 @@ const ZacatecniciBitcoin = ({
       <Head>
         <title>Bankless | Ethereum pro začátečníky</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
       <main className={styles.main}>
         {postsState && <MainBanner data={postsState?.slice(0, 3) || []} />}

--- a/pages/vzdelani/index.tsx
+++ b/pages/vzdelani/index.tsx
@@ -82,6 +82,7 @@ const NovinkyPolkadot = ({
       <Head>
         <title>Bankless | Vzdělání</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
       <main className={styles.main}>
         {postsState && <MainBanner data={postsState?.slice(0, 3) || []} />}

--- a/pages/vzdelani/polkadot/index.tsx
+++ b/pages/vzdelani/polkadot/index.tsx
@@ -73,6 +73,7 @@ const ZacatecniciBitcoin = ({
       <Head>
         <title>Bankless | Polkadot pro začátečníky</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
+        <base target="_blank"/>
       </Head>
       <main className={styles.main}>
         {postsState && <MainBanner data={postsState?.slice(0, 3) || []} />}


### PR DESCRIPTION
Bohužel jak upravit přímo ten <a> tag v té hashovce, protože to generuje přímo ghost a v nastavení jsem nikde nenašel že by šel nastavit default. Takže je to otevírání de facto globální. Takže všechno co není naše stránka se otevře v novém okně. (všechny twittery, pozvánky na discord apod.)